### PR TITLE
Changed url to gamebuino submodule ports/atmel-samd/peripherals

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -66,7 +66,7 @@
 	url = https://github.com/adafruit/Adafruit_CircuitPython_DotStar.git
 [submodule "ports/atmel-samd/peripherals"]
 	path = ports/atmel-samd/peripherals
-	url = https://github.com/Gamebuino/gamebuino-samd-peripherals.git
+	url = https://github.com/Rodot/gamebuino-samd-peripherals.git
 [submodule "frozen/Adafruit_CircuitPython_Crickit"]
 	path = frozen/Adafruit_CircuitPython_Crickit
 	url = https://github.com/adafruit/Adafruit_CircuitPython_Crickit


### PR DESCRIPTION
Changed url to gamebuino submodule ports/atmel-samd/peripherals after hint from @Sorunome.