### PR TITLE
Fixed submodule handling for submodule ports/atmel-samd/modules/Gamebuino-META

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -83,9 +83,6 @@
 [submodule "tools/adabot"]
 	path = tools/adabot
 	url = https://github.com/adafruit/adabot.git
-[submodule "gamebuino-meta"]
-	path = ports/atmel-samd/modules/Gamebuino-Meta
-	url = https://github.com/Gamebuino/Gamebuino-Meta.git
 [submodule "tools/bitmap_font"]
 	path = tools/bitmap_font
 	url = https://github.com/adafruit/Adafruit_CircuitPython_BitmapFont.git
@@ -98,3 +95,6 @@
 [submodule "frozen/circuitpython-stage"]
 	path = frozen/circuitpython-stage
 	url = https://github.com/python-ugame/circuitpython-stage.git
+[submodule "ports/atmel-samd/modules/Gamebuino-META"]
+	path = ports/atmel-samd/modules/Gamebuino-META
+	url = https://github.com/Gamebuino/Gamebuino-META

--- a/ports/atmel-samd/common-hal/gamebuino-meta/make_extra_sources.py
+++ b/ports/atmel-samd/common-hal/gamebuino-meta/make_extra_sources.py
@@ -34,7 +34,7 @@ INC = []
 GB_SRC_DIR = os.path.expanduser("~") + "/.arduino15/packages/gamebuino/hardware/samd/1.2.1/"
 
 SCAN_DIRS = [
-	["modules/Gamebuino-Meta", 1],
+	["modules/Gamebuino-META", 1],
 #	[GB_SRC_DIR + "libraries/SPI", 1],
 #	[GB_SRC_DIR + "cores", 2],
 #	[GB_SRC_DIR + "variants", 2],

--- a/ports/atmel-samd/modules/Gamebuino-Meta
+++ b/ports/atmel-samd/modules/Gamebuino-Meta
@@ -1,1 +1,0 @@
-/home/sorunome/repos/Gamebuino-Meta


### PR DESCRIPTION
Among other things because Gamebuino-Meta was linked to /home/sorunome/repos/Gamebuino-Meta .