### PR TITLE
Fixed lib/utils/printf.c gcc8 build failure

### DIFF
--- a/lib/utils/printf.c
+++ b/lib/utils/printf.c
@@ -103,7 +103,7 @@ STATIC void strn_print_strn(void *data, const char *str, size_t len) {
     strn_print_env->remain -= len;
 }
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 9
 // uClibc requires this alias to be defined, or there may be link errors
 // when linkings against it statically.
 int __GI_vsnprintf(char *str, size_t size, const char *fmt, va_list ap) __attribute__((weak, alias ("vsnprintf")));


### PR DESCRIPTION
I followed the hints from https://github.com/micropython/micropython/issues/4457 .

Error message was:
```
../../lib/utils/printf.c:109:5: error: '__GI_vsnprintf' specifies less restrictive attributes than its target 'vsnprintf': 'nonnull', 'nothrow' [-Werror=missing-attributes]
  109 | int __GI_vsnprintf(char *str, size_t size, const char *fmt, va_list ap) __attribute__((weak, alias ("vsnprintf")));
      |     ^~~~~~~~~~~~~~
../../lib/utils/printf.c:112:5: note: '__GI_vsnprintf' target declared here
  112 | int vsnprintf(char *str, size_t size, const char *fmt, va_list ap) {
      |     ^~~~~~~~~
cc1: all warnings being treated as errors
make: *** [../../py/mkrules.mk:64: build-gamebuino/lib/utils/printf.o] Error 1
`` 