### PR TITLE
Fixed '-Werror=implicit-function-declaration' is not valid for C++

### DIFF
--- a/py/circuitpy_defns.mk
+++ b/py/circuitpy_defns.mk
@@ -60,7 +60,6 @@ BASE_CPPFLAGS = \
 	-fsingle-precision-constant \
 	-fno-strict-aliasing \
 	-Wno-endif-labels \
-	-Werror-implicit-function-declaration \
 	-Wfloat-equal \
 	-Wundef \
 	-Wwrite-strings \


### PR DESCRIPTION
Fixed the following:

```
C++ common-hal/gamebuino-meta/gamebuino-meta.cpp
cc1plus: error: '-Werror=' argument '-Werror=implicit-function-declaration' is not valid for C++ [-Werror]
cc1plus: all warnings being treated as errors
make: *** [../../py/mkrules.mk:68: build-gamebuino/common-hal/gamebuino-meta/gamebuino-meta.o] Error 1
```